### PR TITLE
Fix superflous whitespaces

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -212,10 +212,16 @@ fn setup_app(app: &mut App<Wry>) -> std::result::Result<(), Box<dyn std::error::
                                 return;
                             }
                             
-                            let transcription: String = segments.iter()
+                            let mut transcription: String = segments.iter()
                                 .map(|(_, _, segment)| segment.clone())
                                 .collect::<Vec<String>>()
                                 .join(" ");
+                            // Add trailing space if last character is punctuation, allowing for "chaining" of recordings
+                            if let Some(last_char) = transcription.chars().last() {
+                                if last_char.is_ascii_punctuation() {
+                                    transcription.push(' ');
+                                }
+                            }
                             info!("Transcription: {}", transcription);
 
                             // Create a new Enigo instance for text input

--- a/src-tauri/src/whisper.rs
+++ b/src-tauri/src/whisper.rs
@@ -51,13 +51,13 @@ impl WhisperProcessor {
         let mut segments = Vec::new();
         for i in 0..num_segments {
             let segment = state.full_get_segment_text(i)
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| e.to_string())?.trim().into();
             let start = state.full_get_segment_t0(i)
                 .map_err(|e| e.to_string())? as f32;
             let end = state.full_get_segment_t1(i)
                 .map_err(|e| e.to_string())? as f32;
 
-            info!("[{} - {}]: {}", start, end, segment);
+            info!("[{} - {}]: \"{}\"", start, end, segment);
             segments.push((start, end, segment));
         }
         Ok(segments)


### PR DESCRIPTION
There were whitespaces at the beginning of every transcription and in other (random) places. By trimming the segments, we get rid of these superflous spaces.

Fixes issue [21](https://github.com/dbpprt/whispr/issues/21).